### PR TITLE
handle Action.Logout messages from listener

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -32,12 +32,16 @@ async function listenerTest() {
 			p_info.software
 		);
 	};
-
+	const unannounced = function (p_id: number, p_info: ConnectionInfo) {
+		console.info(
+			`'${p_info.source}' Controller with ID '${p_id}' at '${p_info.address}:${p_info.port}' announced disconnection`
+		);
+	};
 	const lost = function (p_id: number) {
 		console.info(`Controller with ID '${p_id}' is lost`);
 	};
 
-	new Listener(detected, lost, 1000);
+	new Listener(detected, unannounced, lost, 1000);
 
 	while (true) {
 		await sleep(1000);


### PR DESCRIPTION
Wrote a fix, which is hopefully inline with existing style. Handles graceful `DISCOVERER_EXIT_` announcements.
Feel free to disregard if you have a different way of handling it in mind =)
<img width="1069" alt="Screen Shot 2022-01-10 at 2 56 15 PM" src="https://user-images.githubusercontent.com/14239831/148830921-a2c2da1d-8054-402a-94ad-0591dfbff074.png">

