### PR TITLE
support for v2 only db sources

### DIFF
--- a/services/FileTransfer.ts
+++ b/services/FileTransfer.ts
@@ -190,21 +190,25 @@ export class FileTransfer extends Service<FileTransferData> {
 		const message = await this.waitForMessage(MessageId.SourceLocations);
 		if (message) {
 			for (const source of message.sources) {
-				const database = `/${source}/Engine Library/m.db`;
-
-				await this.requestStat(database);
-				const fstatMessage = await this.waitForMessage(MessageId.FileStat);
-				//console.log(fstatMessage);
-				result.push({
-					name: source,
-					database: {
-						location: database,
-						size: fstatMessage.size,
-					},
-				});
+				//try to retrieve V2.x Database2/m.db first. If file doesn't exist or 0 size, retrieve V1.x /m.db
+				const databases = [`/${source}/Engine Library/Database2/m.db`,`/${source}/Engine Library/m.db`];
+				for (let database of databases) {
+					await this.requestStat(database);
+					const fstatMessage = await this.waitForMessage(MessageId.FileStat);
+					if (fstatMessage.size > 0) {
+						result.push({
+							name: source,
+							database: {
+								location: database,
+								size: fstatMessage.size,
+							},
+						});
+						break;
+					}
+				}
 			}
 		}
-
+		
 		return result;
 	}
 

--- a/services/FileTransfer.ts
+++ b/services/FileTransfer.ts
@@ -192,7 +192,7 @@ export class FileTransfer extends Service<FileTransferData> {
 			for (const source of message.sources) {
 				//try to retrieve V2.x Database2/m.db first. If file doesn't exist or 0 size, retrieve V1.x /m.db
 				const databases = [`/${source}/Engine Library/Database2/m.db`,`/${source}/Engine Library/m.db`];
-				for (let database of databases) {
+				for (const database of databases) {
 					await this.requestStat(database);
 					const fstatMessage = await this.waitForMessage(MessageId.FileStat);
 					if (fstatMessage.size > 0) {


### PR DESCRIPTION
If a source was created from EnginePrime 2.x, the file size of `/Engine Library/m.db` is 0. `FileTransfer.getSources()` will return the file location with size 0, and the download will fail.
<img width="1021" alt="Screen Shot 2022-01-11 at 2 24 09 PM" src="https://user-images.githubusercontent.com/14239831/149009307-cb07ed5e-9d5a-487a-bfb8-a491f1c64e66.png">

This fix sends a FileState message to check the size of 2.x database from `/Engine Library/Database2/m.db`. If the file size is 0 (which indicates it is not present on the source), it will try to retrieve the v1.x database from `/Engine Library/m.db`
<img width="1037" alt="Screen Shot 2022-01-11 at 2 43 13 PM" src="https://user-images.githubusercontent.com/14239831/149011103-f3415635-2b00-4286-9236-8c3199c3bd78.png">

Tests done:

- [x] Works if source is connected but no v2.x db is present.
- [x] Works if no source is connected. 